### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ oxygen-sdk-workspace/sdkExtensions/oxygen-gim-extensions/samples/
 runtime-New_configuration/
 oxygen-sdk-workspace/.metadata/
 oxygen-sdk-workspace/RemoteSystemsTempFiles/
+out/
+temp/
+styleguide/

--- a/info-model/bm_InformationModelBookmap.ditamap
+++ b/info-model/bm_InformationModelBookmap.ditamap
@@ -54,7 +54,7 @@
 		<topicref format="dita" href="c_UserInterface.dita" navtitle="User interface elements"
 			type="concept"/>
 	</chapter>
-	<chapter href="c_MapsAndBookMaps.dita" navtitle="Maps and bookmaps" type="concept">
+	<chapter href="c_MapsAndBookmaps.dita" navtitle="Maps and bookmaps">
 		<topicref href="c_Maps.dita" navtitle="Maps" type="concept">
 			<topicref href="c_MapStructure.dita" navtitle="Map structure" type="concept"/>
 			<topicref href="c_MapElements.dita"/>

--- a/info-model/bm_InformationModelBookmap.ditamap
+++ b/info-model/bm_InformationModelBookmap.ditamap
@@ -54,7 +54,7 @@
 		<topicref format="dita" href="c_UserInterface.dita" navtitle="User interface elements"
 			type="concept"/>
 	</chapter>
-	<chapter href="c_MapsAndBookmaps.dita" navtitle="Maps and bookmaps">
+	<chapter href="c_MapsAndBookmaps.dita" navtitle="Maps and bookmaps" type="concept">
 		<topicref href="c_Maps.dita" navtitle="Maps" type="concept">
 			<topicref href="c_MapStructure.dita" navtitle="Map structure" type="concept"/>
 			<topicref href="c_MapElements.dita"/>

--- a/info-model/c_WritingShortDescriptions.dita
+++ b/info-model/c_WritingShortDescriptions.dita
@@ -55,7 +55,7 @@ If you have nothing more to add, do not include a short description"?>
           from cover to cover.<?oxy_comment_end?><note>For navigation purposes, you might want to
             group several topics together under a heading; instead of creating a container topic for
             that heading and a short description, use the &lt;topichead> element in your map. See
-              <xref href="c_mapelements.dita#Maps"/> for more information.<draft-comment>Rephrase
+              <xref href="c_MapElements.dita#Maps"/> for more information.<draft-comment>Rephrase
               this note if they aren't requiring a shortdesc--instead of creating an empty container
               topic for that heading </draft-comment></note></li>
       </ul>


### PR DESCRIPTION
The directories temp, out and styleguide do not need to be tracked by Git. styleguide is another output directory.  There is a directory info-model/rules/temp which would also be excluded by the changed .gitignore rules. I do not understand for what the directory is needed and whether it is a "real" temp directory. It is NOT created when publishing all the defined transformation scenarios.